### PR TITLE
Fix/truncating-of-multibytes-characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ nacl.secret
 .lumberjack
 .lumberjack.new
 .rbx
-lumberjack
+./lumberjack
 logstash-forwarder
 *.DS_Store
 *.idea

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,2 @@
-source :rubygems
-gem "rspec"
-gem "insist"
-gem "stud"
-
-gem "jruby-openssl", :platform => :jruby
+source 'https://rubygems.org'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     stud (0.0.18)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,32 @@
-GEM
-  remote: http://rubygems.org/
+PATH
+  remote: .
   specs:
-    bouncy-castle-java (1.5.0146.1)
-    diff-lcs (1.1.3)
-    insist (0.0.6)
-    jruby-openssl (0.7.7)
-      bouncy-castle-java (>= 1.5.0146.1)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.2)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.2)
-    stud (0.0.5)
+    jls-lumberjack (0.0.20)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    insist (1.0.0)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    stud (0.0.18)
 
 PLATFORMS
-  java
   ruby
 
 DEPENDENCIES
   insist
-  jruby-openssl
+  jls-lumberjack!
   rspec
   stud

--- a/jls-lumberjack.gemspec
+++ b/jls-lumberjack.gemspec
@@ -18,4 +18,7 @@ Gem::Specification.new do |gem|
 
   # This isn't used yet because the new protocol isn't ready
   #gem.add_runtime_dependency "ffi-rzmq", "~> 1.0.0"
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'insist'
+  gem.add_development_dependency 'stud'
 end

--- a/lib/lumberjack/client.rb
+++ b/lib/lumberjack/client.rb
@@ -116,7 +116,7 @@ module Lumberjack
   class Encoder
     def self.to_compressed_frame(hash, sequence)
       compress = Zlib::Deflate.deflate(to_frame(hash, sequence))
-      ["1","C",compress.length,compress].pack("AANA#{compress.length}")
+      ["1", "C", compress.bytesize, compress].pack("AANA#{compress.length}")
     end
 
     def self.to_frame(hash, sequence)

--- a/lib/lumberjack/client.rb
+++ b/lib/lumberjack/client.rb
@@ -93,13 +93,12 @@ module Lumberjack
 
     private
     def write(msg)
-      compress = Zlib::Deflate.deflate(msg)
-      @socket.syswrite(["1","C",compress.length,compress].pack("AANA#{compress.length}"))
+      @socket.syswrite(msg)
     end
 
     public
     def write_hash(hash)
-      frame = to_frame(hash, inc)
+      frame = Encoder.to_compressed_frame(hash, inc)
       ack if (@sequence - (@last_ack + 1)) >= @window_size
       write frame
     end
@@ -112,9 +111,15 @@ module Lumberjack
       @last_ack = @socket.read(4).unpack("N").first
       ack if (@sequence - (@last_ack + 1)) >= @window_size
     end
+  end
 
-    private
-    def to_frame(hash, sequence)
+  class Encoder
+    def self.to_compressed_frame(hash, sequence)
+      compress = Zlib::Deflate.deflate(to_frame(hash, sequence))
+      ["1","C",compress.length,compress].pack("AANA#{compress.length}")
+    end
+
+    def self.to_frame(hash, sequence)
       frame = ["1", "D", sequence]
       pack = "AAN"
       keys = deep_keys(hash)
@@ -122,8 +127,8 @@ module Lumberjack
       pack << "N"
       keys.each do |k|
         val = deep_get(hash,k)
-        key_length = k.length
-        val_length = val.length
+        key_length = k.bytesize
+        val_length = val.bytesize
         frame << key_length
         pack << "N"
         frame << k
@@ -137,7 +142,7 @@ module Lumberjack
     end
 
     private
-    def deep_get(hash, key="")
+    def self.deep_get(hash, key="")
       return hash if key.nil?
       deep_get(
         hash[key.split('.').first],
@@ -146,7 +151,7 @@ module Lumberjack
     end
 
     private
-    def deep_keys(hash, prefix="")
+    def self.deep_keys(hash, prefix="")
       keys = []
       hash.each do |k,v|
         keys << "#{prefix}#{k}" if v.class == String

--- a/spec/lumberjack/client_spec.rb
+++ b/spec/lumberjack/client_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'lumberjack/client'
+require 'lumberjack/server'
+
+describe Lumberjack::Encoder do
+  it 'should creates frames without truncating accentued characters' do
+    content = { 
+      "message" => "Le Canadien de Montréal est la meilleur équipe au monde!",
+      "other" => "éléphant"
+    }
+    
+    parser = Lumberjack::Parser.new
+    parser.feed(Lumberjack::Encoder.to_frame(content, 0)) do |code, sequence, data|
+      expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
+      expect(data["other"].force_encoding('UTF-8')).to eq(content["other"])
+    end
+  end
+end

--- a/spec/lumberjack/client_spec.rb
+++ b/spec/lumberjack/client_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'lumberjack/client'
 require 'lumberjack/server'
@@ -13,6 +14,17 @@ describe Lumberjack::Encoder do
     parser.feed(Lumberjack::Encoder.to_frame(content, 0)) do |code, sequence, data|
       expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
       expect(data["other"].force_encoding('UTF-8')).to eq(content["other"])
+    end
+  end
+
+  it 'should creates frames without dropping multibytes characters' do
+    content = {
+      "message" => "国際ホッケー連盟" # International Hockey Federation
+    }
+
+    parser = Lumberjack::Parser.new
+    parser.feed(Lumberjack::Encoder.to_frame(content, 0)) do |code, sequence, data|
+      expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
     end
   end
 end

--- a/spec/lumberjack/client_spec.rb
+++ b/spec/lumberjack/client_spec.rb
@@ -27,4 +27,15 @@ describe Lumberjack::Encoder do
       expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
     end
   end
+
+  it 'should creates compressed frames' do
+    content = {
+      "message" => "国際ホッケー連盟" # International Hockey Federation
+    }
+
+    parser = Lumberjack::Parser.new
+    parser.feed(Lumberjack::Encoder.to_compressed_frame(content, 0)) do |code, sequence, data|
+      expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
+    end
+  end
 end

--- a/spec/lumberjack_spec.rb
+++ b/spec/lumberjack_spec.rb
@@ -3,6 +3,7 @@ require "tempfile"
 require "lumberjack/server"
 require "insist"
 require "stud/try"
+require "stud/temporary"
 
 describe "lumberjack" do
   before :each do
@@ -21,7 +22,8 @@ describe "lumberjack" do
       :ssl_certificate => @ssl_cert.path,
       :ssl_key => @ssl_key.path
     )
-    @lumberjack = IO.popen("build/bin/lumberjack --host localhost " \
+
+    @lumberjack = IO.popen("./logstash-forwarder --host localhost " \
                            "--port #{@server.port} " \
                            "--ssl-ca-path #{@ssl_cert.path} #{@file.path}",
                            "r")


### PR DESCRIPTION
Fix an issue when creating frames with accented characters, I have changed the frame creation to use bytesize instead of length.
I have also moved the encoding method outside of the client class, it make things easier to test and support.

The test suite is currently broken and we cannot run the tests of the `lumberjack_spec`, the parameters format changed and the test were not updated.

Fixes: https://github.com/elasticsearch/logstash/issues/1480
Fixes: https://github.com/elasticsearch/logstash/issues/1807