### PR TITLE
Use HTTPS URL as Rubygem source instead of deprecated symbol shortcut.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 gem "rspec"
 gem "insist"
 gem "stud"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     bouncy-castle-java (1.5.0146.1)
     diff-lcs (1.1.3)


### PR DESCRIPTION
The `:rubygems` symbol points to an insecure HTTP source. Using the full URL string is now the recommended approach.