### PR TITLE
New init script options added in the make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.3.1
+VERSION=0.3.1-3
 
 # By default, all dependencies (zeromq, etc) will be downloaded and installed
 # locally. You can change this if you are deploying your own.
@@ -45,6 +45,28 @@ vendor-clean:
 	$(MAKE) -C vendor/zlib/ clean
 
 rpm deb: PREFIX=/opt/logstash-forwarder
+
+deb6 deb7: | build-all
+	fpm -s dir -t deb -n logstash-forwarder -v $(VERSION) \
+		--replaces lumberjack \
+		--exclude '*.a' --exclude 'lib/pkgconfig/zlib.pc' \
+		--description "a log shipping tool" \
+		--url "https://github.com/elasticsearch/logstash-forwarder" \
+		build/bin/logstash-forwarder=$(PREFIX)/bin/ \
+		build/bin/logstash-forwarder.sh=$(PREFIX)/bin/ \
+		logstash-forwarder.init.Debian=/etc/init.d/logstash-forwarder
+
+rpm5 rpm6: | build-all
+	fpm -s dir -t rpm -n logstash-forwarder -v $(VERSION) \
+		--replaces lumberjack \
+		--exclude '*.a' --exclude 'lib/pkgconfig/zlib.pc' \
+		--description "a log shipping tool" \
+		--url "https://github.com/elasticsearch/logstash-forwarder" \
+		build/bin/logstash-forwarder=$(PREFIX)/bin/ \
+		build/bin/logstash-forwarder.sh=$(PREFIX)/bin/ \
+		logstash-forwarder.init.RedHat=/etc/init.d/logstash-forwarder
+
+
 rpm deb: | build-all
 	fpm -s dir -t $@ -n logstash-forwarder -v $(VERSION) \
 		--replaces lumberjack \
@@ -53,7 +75,8 @@ rpm deb: | build-all
 		--url "https://github.com/elasticsearch/logstash-forwarder" \
 		build/bin/logstash-forwarder=$(PREFIX)/bin/ \
 		build/bin/logstash-forwarder.sh=$(PREFIX)/bin/ \
-		logstash-forwarder.init=/etc/init.d/logstash-forwarder
+		logstash-forwarder.init.RedHat=/etc/init.d/logstash-forwarder
+
 
 # Vendor'd dependencies
 # If VENDOR contains 'zeromq' download and build it.

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ To build the packages, you will need ruby and fpm installed.
 
 Now build an rpm:
 
-        make rpm
+        make rpm (rpm5,rpm6 build with new init script)
 
 Or:
 
-        make deb
+        make deb (deb6, deb7 build with new init script)
 
 ## Installing it (via packages only)
 

--- a/logstash-forwarder.init.Debian
+++ b/logstash-forwarder.init.Debian
@@ -1,0 +1,72 @@
+#! /bin/sh
+
+# From The Logstash Book
+# The original of this file can be found at: http://logstashbook.com/code/index.html
+# https://github.com/jamtur01/logstashbook-code/blob/master/code/4/logstash_forwarder_debian_init
+
+### BEGIN INIT INFO
+# Provides:          logstash-forwarder
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start daemon at boot time
+# Description:       Enable service provided by daemon.
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+NAME="logstash-forwarder"
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+LOGSTASH_FORWARDER_BIN="/opt/logstash-forwarder/bin/logstash-forwarder"
+PID_FILE="/var/run/$NAME.pid"
+CWD=`pwd`
+
+start () {
+        COMMAND="${LOGSTASH_FORWARDER_BIN}"
+
+        log_daemon_msg "Starting $NAME"
+        if start-stop-daemon --start --quiet --oknodo --pidfile "$PID_FILE" -b -m -N 19 --exec $COMMAND -- $LOGSTASH_FORWARDER_OPTIONS; then
+                log_end_msg 0
+        else
+                log_end_msg 1
+        fi
+}
+
+stop () {
+        start-stop-daemon --stop --quiet --oknodo --pidfile "$PID_FILE"
+}
+
+status () {
+        status_of_proc -p $PID_FILE "" "$NAME"
+}
+
+case $1 in
+        start)
+                if status; then exit 0; fi
+                start
+                ;;
+        stop)
+                stop
+                ;;
+        reload)
+                stop
+                start
+                ;;
+        restart)
+                stop
+                start
+                ;;
+        status)
+                status && exit 0 || exit $?
+                ;;
+        *)
+                echo "Usage: $0 {start|stop|restart|reload|status}"
+                exit 1
+                ;;
+esac
+
+exit 0

--- a/logstash-forwarder.init.RedHat
+++ b/logstash-forwarder.init.RedHat
@@ -1,0 +1,65 @@
+#! /bin/sh
+# From The Logstash Book
+# The original of this file can be found at: http://logstashbook.com/code/index.html
+# https://github.com/jamtur01/logstashbook-code/blob/master/code/4/logstash_forwarder_redhat_init
+#
+# logstash-forwarder Start/Stop logstash-forwarder
+#
+# chkconfig: 345 99 99
+# description: logstash-forwarder
+# processname: logstash-forwarder
+
+# Check config
+#test -f /etc/sysconfig/logstash-forwarder && . /etc/sysconfig/logstash-forwarder
+
+LOGSTASH_FORWARDER_OPTIONS=" --config /etc/logstash-forwarder -spool-size 1024 -log-to-syslog"
+
+LOGSTASH_FORWARDER_BIN="/opt/logstash-forwarder/bin/logstash-forwarder"
+
+find_logstash_forwarder_process () {
+    PIDTEMP=`pgrep -f ${LOGSTASH_FORWARDER_BIN}`
+    # Pid not found
+    if [ "x$PIDTEMP" = "x" ]; then
+        PID=-1
+    else
+        PID=$PIDTEMP
+    fi
+}
+
+start () {
+  nohup ${LOGSTASH_FORWARDER_BIN} ${LOGSTASH_FORWARDER_OPTIONS} &
+}
+
+stop () {
+  pkill -f ${LOGSTASH_FORWARDER_BIN}
+}
+
+case $1 in
+start)
+        start
+        ;;
+stop)
+        stop
+        exit 0;
+        ;;
+reload)
+        stop
+        start
+        ;;
+restart)
+        stop
+        start
+        ;;
+status)
+        find_logstash_forwarder_process
+        if [ $PID -gt 0 ]; then
+            exit 0
+        else
+            exit 1
+fi
+        ;;
+*fi)
+        echo $"Usage: $0 {start|stop|restart|reload|status}"
+        RETVAL=1
+esac
+exit 0


### PR DESCRIPTION
Added two new init scripts as the Debian and Redhat init scripts never seemed to work for our environment.

These init scripts are optional and can be used with new make file options.