### PR TITLE
Make usage of the address in the Logstash-Forwarder server

### DIFF
--- a/lib/lumberjack/server.rb
+++ b/lib/lumberjack/server.rb
@@ -31,7 +31,8 @@ module Lumberjack
         end
       end
 
-      @tcp_server = TCPServer.new(@options[:port])
+      @tcp_server = TCPServer.new(@options[:address], @options[:port])
+ 
       # Query the port in case the port number is '0'
       # TCPServer#addr == [ address_family, port, address, address ]
       @port = @tcp_server.addr[1]


### PR DESCRIPTION
Fixes #326 . Now the host option in the logstash-input-lumberjack works.