### PR TITLE
Add codecs to be connection independent

### DIFF
--- a/jls-lumberjack.gemspec
+++ b/jls-lumberjack.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = []
   gem.name          = "jls-lumberjack"
   gem.require_paths = ["lib"]
-  gem.version       = "0.0.20"
+  gem.version       = "0.0.21"
 
   # This isn't used yet because the new protocol isn't ready
   #gem.add_runtime_dependency "ffi-rzmq", "~> 1.0.0"

--- a/lib/lumberjack/server.rb
+++ b/lib/lumberjack/server.rb
@@ -246,7 +246,7 @@ module Lumberjack
     end
 
     def data(sequence, map, &block)
-      block.call(map)
+      block.call(map) if block_given?
       if (sequence - @last_ack) >= @window_size
         @fd.syswrite(["1A", sequence].pack("A*N"))
         @last_ack = sequence


### PR DESCRIPTION
So we can have real multiline codecs used within the context of logstash-forwarder.