### PR TITLE
Fixed a bunch of minor issues that causes test not to work in JRuby environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gem "rspec"
 gem "insist"
 gem "stud"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,23 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    bouncy-castle-java (1.5.0146.1)
-    diff-lcs (1.1.3)
-    insist (0.0.6)
-    jruby-openssl (0.7.7)
-      bouncy-castle-java (>= 1.5.0146.1)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.2)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.2)
-    stud (0.0.5)
+    diff-lcs (1.2.5)
+    insist (1.0.0)
+    jruby-openssl (0.9.6-java)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.0)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.1)
+    stud (0.0.19)
 
 PLATFORMS
   java

--- a/lib/lumberjack/server.rb
+++ b/lib/lumberjack/server.rb
@@ -231,7 +231,7 @@ module Lumberjack
       # EOF or other read errors, only action is to shutdown which we'll do in
       # 'ensure'
     ensure
-      close
+      close rescue 'Already closed stream'
     end # def run
 
     def close

--- a/spec/lumberjack_spec.rb
+++ b/spec/lumberjack_spec.rb
@@ -49,7 +49,8 @@ describe "lumberjack" do
       File.unlink(path) if File.exists?(path)
     end
     Process::kill("KILL", lsf.pid)
-    Process::wait(lsf.pid)
+    #Calling this method raises a SystemCallError if there are no child processes.
+    Process::wait(lsf.pid) rescue ''
   end
 
   before do


### PR DESCRIPTION
Bunch of minor issues:

* Fixed the source rubygem issue and make it use the actual https endpoint style.
* Made sure also to update the Gemfile.lock to use the latest set of available gem versions.
    
* Workaround, somehow,  the couple of issues that caused JRuby to complain if the file descriptor for the SSLSocket was already closed and if there was no process to wait for. Feel free to keep them or provide another more nice way that would imply a redesign of the server class.

Related to #366 