### PR TITLE
Support for multibyte strings.

### DIFF
--- a/spec/lumberjack/client_spec.rb
+++ b/spec/lumberjack/client_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'lumberjack/client'
+require 'lumberjack/server'
 require "socket"
 require "thread"
 require "openssl"
@@ -58,6 +59,39 @@ describe "Lumberjack::Client" do
 
       end
     end
+  end
 
+  describe Lumberjack::Encoder do
+    it 'should creates frames without truncating accentued characters' do
+      content = {
+        "message" => "Le Canadien de Montréal est la meilleur équipe au monde!",
+        "other" => "éléphant"
+      }
+      parser = Lumberjack::Parser.new
+      parser.feed(Lumberjack::Encoder.to_frame(content, 0)) do |code, sequence, data|
+        expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
+        expect(data["other"].force_encoding('UTF-8')).to eq(content["other"])
+      end
+    end
+
+    it 'should creates frames without dropping multibytes characters' do
+      content = {
+        "message" => "国際ホッケー連盟" # International Hockey Federation
+      }
+      parser = Lumberjack::Parser.new
+      parser.feed(Lumberjack::Encoder.to_frame(content, 0)) do |code, sequence, data|
+        expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
+      end
+    end
+
+    it 'should creates compressed frames' do
+      content = {
+        "message" => "国際ホッケー連盟" # International Hockey Federation
+      }
+      parser = Lumberjack::Parser.new
+      parser.feed(Lumberjack::Encoder.to_compressed_frame(content, 0)) do |code, sequence, data|
+        expect(data["message"].force_encoding('UTF-8')).to eq(content["message"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix an issue when creating frames with accented characters, I have
changed the frame creation to use bytesize instead of length.  I have
also moved the encoding method outside of the client class, it make
things easier to test and support.

Fixes: elasticsearch/logstash#1480
Fixes: elasticsearch/logstash#1807