### PR TITLE
ensure all bytes of a message are written to SSLSocket

### DIFF
--- a/lib/lumberjack/client.rb
+++ b/lib/lumberjack/client.rb
@@ -93,7 +93,13 @@ module Lumberjack
     private
     def write(msg)
       compress = Zlib::Deflate.deflate(msg)
-      @socket.syswrite(["1","C",compress.bytesize,compress].pack("AANA#{compress.bytesize}"))
+      payload = ["1","C",compress.length,compress].pack("AANA#{compress.length}")
+      # SSLSocket has a limit of 16k per message
+      # execute multiple writes if needed
+      bytes_written = 0
+      while bytes_written < payload.bytesize
+        bytes_written += @socket.syswrite(payload.byteslice(bytes_written..-1))
+      end
     end
 
     public


### PR DESCRIPTION
Writing a large message on the client side using SSLSocket#syswrite will result in an incomplete message. This does not occur with SSLSocket#write, TCPSocket#syswrite or TCPSocket#write.

Test scenario here: https://gist.github.com/jsvd/5c18d2a8e81c4fdbc368

the fix is just a loop that calls syswrite until the full payload is transmitted.